### PR TITLE
removed unused data call

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,6 @@ No modules.
 | [aws_ecs_task_definition.task_definition](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ecs_task_definition) | data source |
 | [aws_iam_policy_document.ecs_task_execution_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_lb_target_group.target_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/lb_target_group) | data source |
-| [aws_security_group.loadbalancer](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/security_group) | data source |
 | [aws_subnets.shared-private](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnets) | data source |
 | [aws_vpc.shared](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/vpc) | data source |
 

--- a/main.tf
+++ b/main.tf
@@ -19,23 +19,11 @@ data "aws_subnets" "shared-private" {
   }
 }
 
-data "aws_security_group" "loadbalancer" {
-  vpc_id = data.aws_vpc.shared.id
-  tags = {
-    "Name" = "${var.app_name}-loadbalancer-security-group"
-  }
-}
-
 data "aws_lb_target_group" "target_group" {
   tags = {
     "Name" = "${var.app_name}-tg-${var.environment}"
   }
 }
-
-# resource "aws_iam_service_linked_role" "ecs" {
-#   aws_service_name = "ecs.amazonaws.com"
-#   custom_suffix    = var.app_name
-# }
 
 resource "aws_autoscaling_group" "cluster-scaling-group" {
   vpc_zone_identifier = sort(data.aws_subnets.shared-private.ids)


### PR DESCRIPTION
The `aws_security_group "loadbalancer"` data call is not used, so to prevent confusion it has been removed