### PR TITLE
Resolve data call issue for loadbalancer target groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,9 +104,9 @@ No modules.
 | <a name="input_ec2_ingress_rules"></a> [ec2\_ingress\_rules](#input\_ec2\_ingress\_rules) | Security group ingress rules for the cluster EC2s | <pre>map(object({<br>    description     = string<br>    from_port       = number<br>    to_port         = number<br>    protocol        = string<br>    security_groups = list(string)<br>    cidr_blocks     = list(string)<br>  }))</pre> | n/a | yes |
 | <a name="input_ec2_max_size"></a> [ec2\_max\_size](#input\_ec2\_max\_size) | Max Number of EC2s in the cluster | `string` | n/a | yes |
 | <a name="input_ec2_min_size"></a> [ec2\_min\_size](#input\_ec2\_min\_size) | Min Number of EC2s in the cluster | `string` | n/a | yes |
-| <a name="input_environment"></a> [environment](#input\_environment) | The environment where resources are to be created (development, test, preprod, production) | `string` | n/a | yes |
 | <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | EC2 instance type to run in the ECS cluster | `string` | n/a | yes |
 | <a name="input_key_name"></a> [key\_name](#input\_key\_name) | Key to access EC2s in ECS cluster | `string` | n/a | yes |
+| <a name="input_lb_tg_name"></a> [lb\_tg\_name](#input\_lb\_tg\_name) | Load balancer target group name used by ECS service | `string` | n/a | yes |
 | <a name="input_network_mode"></a> [network\_mode](#input\_network\_mode) | The network mode used for the containers in the task. If OS used is Windows network\_mode must equal none. | `string` | n/a | yes |
 | <a name="input_server_port"></a> [server\_port](#input\_server\_port) | The port the containers will be listening on | `string` | n/a | yes |
 | <a name="input_subnet_set_name"></a> [subnet\_set\_name](#input\_subnet\_set\_name) | The name of the subnet set associated with the account | `string` | n/a | yes |

--- a/main.tf
+++ b/main.tf
@@ -20,9 +20,7 @@ data "aws_subnets" "shared-private" {
 }
 
 data "aws_lb_target_group" "target_group" {
-  tags = {
-    "Name" = "${var.app_name}-tg-${var.environment}"
-  }
+  name = var.lb_tg_name
 }
 
 resource "aws_autoscaling_group" "cluster-scaling-group" {

--- a/variables.tf
+++ b/variables.tf
@@ -47,11 +47,6 @@ variable "ec2_min_size" {
   description = "Min Number of EC2s in the cluster"
 }
 
-variable "environment" {
-  type        = string
-  description = "The environment where resources are to be created (development, test, preprod, production)"
-}
-
 variable "instance_type" {
   type        = string
   description = "EC2 instance type to run in the ECS cluster"

--- a/variables.tf
+++ b/variables.tf
@@ -62,6 +62,11 @@ variable "key_name" {
   description = "Key to access EC2s in ECS cluster"
 }
 
+variable "lb_tg_name" {
+  type        = string
+  description = "Load balancer target group name used by ECS service"
+}
+
 variable "network_mode" {
   type        = string
   description = "The network mode used for the containers in the task. If OS used is Windows network_mode must equal none."


### PR DESCRIPTION
The previous data call for `aws_lb_target_group` contained a non-functional filter based on tags. This filtering method is not supported. In cases where a single target group is returned the data call is functional, but once more than one target group is returned it fails to function.
This PR adds a simple variable-based lookup for the target group to be used by the ECS service