### PR TITLE
Amending provider name to fix terratests

### DIFF
--- a/test/unit-test/locals.tf
+++ b/test/unit-test/locals.tf
@@ -35,7 +35,7 @@ locals {
   subnet_set_name = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}"
 
   is_live       = [substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-production" || substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-preproduction" ? "live" : "non-live"]
-  provider_name = "testing-test"
+  provider_name = "core-vpc-${local.environment}"
 
   domain_types = { for dvo in aws_acm_certificate.external.domain_validation_options : dvo.domain_name => {
     name   = dvo.resource_record_name


### PR DESCRIPTION
The reference to the relevant core vpc account name was incorrect.