### PR TITLE
Remove blanket exclusions of checkov scans

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+  pull-requests: write
 jobs:
   docs:
     runs-on: ubuntu-latest

--- a/.github/workflows/go-terratest.yml
+++ b/.github/workflows/go-terratest.yml
@@ -5,6 +5,9 @@ env:
   AWS_ACCESS_KEY_ID:  ${{ secrets.AWS_ACCESS_KEY_ID }}
   AWS_SECRET_ACCESS_KEY:  ${{ secrets.AWS_SECRET_ACCESS_KEY }}
   TF_IN_AUTOMATION: true
+
+permissions:
+  contents: read
 jobs:
   go-tests:
     name: Run Go Unit Tests

--- a/.github/workflows/terraform-static-analysis.yml
+++ b/.github/workflows/terraform-static-analysis.yml
@@ -31,7 +31,7 @@ jobs:
       with:
         scan_type: single
         tfsec_exclude: AWS089, AWS099, AWS009, AWS097, AWS018
-        checkov_exclude: CKV_GIT_1,CKV_AWS_289,CKV_AWS_290,CKV_AWS_288,CKV_AWS_249,CKV2_GHA_1
+        checkov_exclude: CKV_GIT_1
 
   terraform-static-analysis-full-scan:
     permissions:
@@ -51,4 +51,4 @@ jobs:
       with:
         scan_type: full
         tfsec_exclude: AWS089, AWS099, AWS009, AWS097, AWS018
-        checkov_exclude: CKV_GIT_1,CKV_AWS_289,CKV_AWS_290,CKV_AWS_288,CKV_AWS_249,CKV2_GHA_1
+        checkov_exclude: CKV_GIT_1


### PR DESCRIPTION
Each scan exclusion should be justified, have the violating code fixed, or should at the very least be visible