### PR TITLE
Sets required_providers to ~> 5.30

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 4.0"
+      version = "~> 5.30"
       source  = "hashicorp/aws"
     }
   }


### PR DESCRIPTION
Sets required_providers version to ~> 5.30 instead of the 5.32 offered by dependabot so it's in line with the required version in other module repos.